### PR TITLE
Separate elements printed by executable

### DIFF
--- a/bin/lorem
+++ b/bin/lorem
@@ -18,13 +18,13 @@ die usage()
 
 my $lorem = Text::Lorem->new;
 if ($opt_w) {
-    print $lorem->words($opt_w);
+    print join " ", $lorem->words($opt_w);
 }
 elsif ($opt_s) {
-    print $lorem->sentences($opt_s);
+    print join " ", $lorem->sentences($opt_s);
 }
 elsif ($opt_p) {
-    print $lorem->paragraphs($opt_p);
+    print join "\n", $lorem->paragraphs($opt_p);
 }
 else {
     print $lorem->paragraphs(1);


### PR DESCRIPTION
Currently, elements appear with no spaces between them. For instance,

lorem -w 10

produces a single (and very long) word.